### PR TITLE
fix: Get `nonce` value for sender from network

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -332,7 +332,12 @@ export async function makeStxTokenTransfer(input: MultisigTxInput): Promise<Stac
   // Conditional fields
   if (input.nonce) {
     options.nonce = BigInt(input.nonce);
+  } else {
+    // Shouldn't Stacks.js automatically set nonce if not given?
+    const addr = makeMultiSigAddr(publicKeys, numSignatures);
+    options.nonce = await StxTx.getNonce(addr);
   }
+
   if (input.fee) {
     options.fee = BigInt(input.fee);
   }


### PR DESCRIPTION
Lookup the `nonce` value for a transaction from the Stacks network 

Fixes #5 